### PR TITLE
Remove depacketizer thread

### DIFF
--- a/src/com/limelight/nvstream/av/audio/AudioStream.java
+++ b/src/com/limelight/nvstream/av/audio/AudioStream.java
@@ -7,7 +7,6 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.util.LinkedList;
-import java.util.concurrent.LinkedBlockingQueue;
 
 import com.limelight.nvstream.NvConnectionListener;
 import com.limelight.nvstream.av.ByteBufferDescriptor;
@@ -18,8 +17,6 @@ public class AudioStream {
 	public static final int RTCP_PORT = 47999;
 	
 	public static final int RTP_RECV_BUFFER = 64 * 1024;
-	
-	private LinkedBlockingQueue<RtpPacket> packets = new LinkedBlockingQueue<RtpPacket>(100);
 	
 	private DatagramSocket rtp;
 	
@@ -77,8 +74,6 @@ public class AudioStream {
 		
 		startReceiveThread();
 		
-		startDepacketizerThread();
-		
 		startDecoderThread();
 		
 		startUdpPingThread();
@@ -104,39 +99,13 @@ public class AudioStream {
 		streamListener.streamInitialized(OpusDecoder.getChannelCount(), OpusDecoder.getSampleRate());
 	}
 	
-	private void startDepacketizerThread()
-	{
-		// This thread lessens the work on the receive thread
-		// so it can spend more time waiting for data
-		Thread t = new Thread() {
-			@Override
-			public void run() {
-				while (!isInterrupted())
-				{
-					RtpPacket packet;
-					
-					try {
-						packet = packets.take();
-					} catch (InterruptedException e) {
-						connListener.connectionTerminated(e);
-						return;
-					}
-					
-					depacketizer.decodeInputData(packet);
-				}
-			}
-		};
-		threads.add(t);
-		t.setName("Audio - Depacketizer");
-		t.start();
-	}
-	
 	private void startDecoderThread()
 	{
 		// Decoder thread
 		Thread t = new Thread() {
 			@Override
 			public void run() {
+				
 				while (!isInterrupted())
 				{
 					ByteBufferDescriptor samples;
@@ -149,6 +118,7 @@ public class AudioStream {
 					}
 					
 					streamListener.playDecodedAudio(samples.data, samples.offset, samples.length);
+					
 				}
 			}
 		};
@@ -170,16 +140,13 @@ public class AudioStream {
 				{
 					try {
 						rtp.receive(packet);
+						desc.length = packet.getLength();
+						depacketizer.decodeInputData(new RtpPacket(desc));
+						desc.reinitialize(new byte[1500], 0, 1500);
+						packet.setData(desc.data, desc.offset, desc.length);
 					} catch (IOException e) {
 						connListener.connectionTerminated(e);
 						return;
-					}
-
-					// Give the packet to the depacketizer thread
-					desc.length = packet.getLength();
-					if (packets.offer(new RtpPacket(desc))) {
-						desc.reinitialize(new byte[1500], 0, 1500);
-						packet.setData(desc.data, desc.offset, desc.length);
 					}
 				}
 			}


### PR DESCRIPTION
Audio latency is currently a big problem in Limelight. The main cause lay in the excessive usage of buffers. While video can be played faster this isn't the case with audio. So if you wait long enough buffers will fill and the audio delay increase. At least on the Raspberry Pi the situation can be improved by removing the depacketizer thread. This thread can be merged with the receive thread because the OS already provides us with a packet buffer (RTP_RECV_BUFFER) so there is no need to maintain another one.

For Limelight-pi I decreased the size of the the other buffers as well in irtimmer@dc35277393a7548215b3838b719421251a2d3a16 to improve audio latency. It works perfectly over wired but I have no idea what the effect is on wireless connections. Maybe it would be nice to make these configurable so you can choose between less latency (for wired) or less artifacts (for wireless)
