### PR TITLE
Reassemble NAL's early

### DIFF
--- a/src/com/limelight/nvstream/av/video/VideoDepacketizer.java
+++ b/src/com/limelight/nvstream/av/video/VideoDepacketizer.java
@@ -193,6 +193,10 @@ public class VideoDepacketizer {
 				// Add a buffer descriptor describing the NAL data in this packet
 				avcNalDataChain.add(data);
 				avcNalDataLength += location.offset-start;
+				
+				// Reassemble the NALs if this was the last packet for this frame
+				if (packet.getPacketIndex() + 1 == packet.getTotalPackets())
+					reassembleAvcNal();
 			}
 		}
 	}


### PR DESCRIPTION
I try to improve the latency and concluded the addInputData is buffering a whole frame. Which results in a extra latency of 16ms (60 fps) or 33ms (30 fps). Like the addInputDataO1 I now use the packets index to know when to reassemble NAL's. I'm not sure if this will break the other code to prevent artifects but at least on the Raspberry Pi I couldn't find any differences except for some improved latency.
