### PR TITLE
Fix off-by-one when looking for an I-frame NAL

### DIFF
--- a/src/com/limelight/nvstream/av/video/VideoDepacketizer.java
+++ b/src/com/limelight/nvstream/av/video/VideoDepacketizer.java
@@ -274,6 +274,9 @@ public class VideoDepacketizer {
 						// Reassemble any pending NAL
 						reassembleFrame(packet.getFrameIndex());
 						
+						// Reload cachedSpecialDesc after reassembleFrame overwrote it
+						NAL.getSpecialSequenceDescriptor(location, cachedSpecialDesc);
+						
 						if (isReferencePictureNalu(cachedSpecialDesc.data[cachedSpecialDesc.offset+cachedSpecialDesc.length])) {
 							// This is the NALU code for I-frame data
 							waitingForIdrFrame = false;


### PR DESCRIPTION
Between [finding the NAL][1] and [checking its type][2], `reassembleFrame` is called and [overwrites][3] the `cachedSpecialDesc` with the data and NAL type from the previous NAL. If the only IDR NAL in the packet is the last NAL in the packet, it gets missed and the depacketizer is stuck waiting for it.

[1]: https://github.com/moonlight-stream/moonlight-common/blob/d4efb7884055b483f249a9efd3c9b1a735ec8eb2/src/com/limelight/nvstream/av/video/VideoDepacketizer.java#L261
[2]: https://github.com/moonlight-stream/moonlight-common/blob/d4efb7884055b483f249a9efd3c9b1a735ec8eb2/src/com/limelight/nvstream/av/video/VideoDepacketizer.java#L277
[3]: https://github.com/moonlight-stream/moonlight-common/blob/d4efb7884055b483f249a9efd3c9b1a735ec8eb2/src/com/limelight/nvstream/av/video/VideoDepacketizer.java#L162